### PR TITLE
Update voxel-crunch and duplex-emitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "voxel-engine": "0.20.0",
-    "voxel-crunch": "0.1.1",
-    "duplex-emitter": "0.1.10",
+    "voxel-crunch": "0.2.1",
+    "duplex-emitter": "2.1.2",
     "hat": "0.0.3",
     "voxel": "0.3.1",
     "extend": "1.2.1"


### PR DESCRIPTION
note: may require further testing (but I was getting JSON parse errors on "," with the older duplex-emitter)
